### PR TITLE
Issues about comparing double values

### DIFF
--- a/kernel/src/main/java/cn/crowdos/kernel/constraint/Coordinate.java
+++ b/kernel/src/main/java/cn/crowdos/kernel/constraint/Coordinate.java
@@ -17,7 +17,8 @@ public class Coordinate implements Condition{
         if (this == obj) return true;
         if (obj instanceof Coordinate){
             Coordinate anCoord = (Coordinate) obj;
-            return this.longitude == anCoord.longitude && this.latitude == anCoord.latitude;
+            return (Double.valueOf(this.longitude).compareTo(Double.valueOf(anCoord.longitude)) == 0)
+                    && (Double.valueOf(this.latitude).compareTo(Double.valueOf(anCoord.latitude)) == 0);
         }
         return false;
     }


### PR DESCRIPTION
It's not recommend to compare double values using the '==' operator, since floating values might not be accurately stored as binary.